### PR TITLE
Bug 469922. Убран лог с количеством "отправленных" уведомлений

### DIFF
--- a/src/Packages/Sungero.Examples/Sungero.Examples.Server/AcquaintanceTask/AcquaintanceTaskServerFunctions.cs
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Server/AcquaintanceTask/AcquaintanceTaskServerFunctions.cs
@@ -23,7 +23,6 @@ namespace Sungero.Examples.Server
       
       Logger.Debug($"RemindParticipants. Found {incompleteAssignments.Count} incomplete assignments");
       
-      var sentCount = 0;
       foreach (var assignment in incompleteAssignments)
       {
         var performer = Sungero.Examples.Employees.As(assignment.Performer);
@@ -33,11 +32,7 @@ namespace Sungero.Examples.Server
         var subject = assignment.Subject;
         var text = $"У вас невыполненное задание: {assignment.Subject}";
         this.SendNotificationToEmployee(performer, subject, text);
-        
-        sentCount++;
       }
-      
-      Logger.Debug($"RemindParticipants. Sent {sentCount} notifications");
     }
     
     /// <summary>

--- a/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.Company/Module.mtd
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.Company/Module.mtd
@@ -362,7 +362,7 @@
       ]
     }
   ],
-  "Version": "26.1.0.6",
+  "Version": "26.1.0.11",
   "Widgets": [],
   "Versions": [
     {

--- a/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.Docflow/Module.mtd
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.Docflow/Module.mtd
@@ -545,7 +545,7 @@
       ]
     }
   ],
-  "Version": "26.1.0.6",
+  "Version": "26.1.0.11",
   "Widgets": [],
   "Versions": [
     {

--- a/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.Exchange/Module.mtd
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.Exchange/Module.mtd
@@ -121,7 +121,7 @@
   "ResourceInterfaceAssemblyName": "Sungero.Domain.Interfaces",
   "ResourceInterfaceNamespace": "Sungero.Examples.Module.Exchange",
   "SpecialFolders": [],
-  "Version": "26.1.0.6",
+  "Version": "26.1.0.11",
   "Widgets": [],
   "Versions": [
     {

--- a/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.RecordManagement/Module.mtd
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.RecordManagement/Module.mtd
@@ -541,7 +541,7 @@
       ]
     }
   ],
-  "Version": "26.1.0.6",
+  "Version": "26.1.0.11",
   "Widgets": [],
   "Versions": [
     {

--- a/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.RecordManagementUI/Module.mtd
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.RecordManagementUI/Module.mtd
@@ -294,7 +294,7 @@
       ]
     }
   ],
-  "Version": "26.1.0.6",
+  "Version": "26.1.0.11",
   "Widgets": [],
   "Versions": [
     {

--- a/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.SmartProcessing/Module.mtd
+++ b/src/Packages/Sungero.Examples/Sungero.Examples.Shared/Sungero.SmartProcessing/Module.mtd
@@ -145,7 +145,7 @@
         {
           "Name": "documents",
           "ParameterType": "global::System.Collections.Generic.IEnumerable<global::Sungero.Docflow.IOfficialDocument>",
-          "ParameterTypeFullName": "System.Collections.Generic.IEnumerable"
+          "ParameterTypeFullName": "System.Collections.Generic.IEnumerable`1[[Sungero.Docflow.IOfficialDocument, Sungero.Domain.Interfaces]]"
         }
       ],
       "ReturnType": "global::Sungero.Docflow.IOfficialDocument",
@@ -156,7 +156,7 @@
   "ResourceInterfaceAssemblyName": "Sungero.Domain.Interfaces",
   "ResourceInterfaceNamespace": "Sungero.Examples.Module.SmartProcessing",
   "SpecialFolders": [],
-  "Version": "26.1.0.6",
+  "Version": "26.1.0.11",
   "Widgets": [],
   "Versions": [
     {


### PR DESCRIPTION
Вместо тысячи слов, было:
<img width="1594" height="162" alt="image" src="https://github.com/user-attachments/assets/b84d46e5-2161-4bef-9b2e-7e7323c790fd" />
Стало:
<img width="1840" height="386" alt="image" src="https://github.com/user-attachments/assets/75a29075-a23f-4422-b437-014054c67bd4" />
